### PR TITLE
Assume the buildpack is built with packit

### DIFF
--- a/packing_tools.go
+++ b/packing_tools.go
@@ -1,7 +1,6 @@
 package freezer
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -29,11 +28,6 @@ func (p PackingTools) WithExecutable(executable Executable) PackingTools {
 }
 
 func (p PackingTools) Execute(buildpackDir, output, version string, cached bool) error {
-	_, err := os.Stat(filepath.Join(buildpackDir, ".packit"))
-	if err != nil {
-		return fmt.Errorf("unable to find .packit in buildpack directory: %w", err)
-	}
-
 	args := []string{
 		"pack",
 		"--buildpack", filepath.Join(buildpackDir, "buildpack.toml"),

--- a/packing_tools_test.go
+++ b/packing_tools_test.go
@@ -28,7 +28,6 @@ func testPackingTools(t *testing.T, context spec.G, it spec.S) {
 		var err error
 		buildpackDir, err = ioutil.TempDir("", "buildpack-dir")
 		Expect(err).ToNot(HaveOccurred())
-		Expect(ioutil.WriteFile(filepath.Join(buildpackDir, ".packit"), nil, 0600)).To(Succeed())
 
 		executable = &fakes.Executable{}
 
@@ -69,18 +68,6 @@ func testPackingTools(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		context("failure cases", func() {
-			context("when the buildpack is not a packit buildpack", func() {
-				it.Before(func() {
-					os.Remove(filepath.Join(buildpackDir, ".packit"))
-				})
-
-				it("returns an error", func() {
-					err := packingTools.Execute(buildpackDir, "some-output", "some-version", true)
-					Expect(err).To(MatchError(ContainSubstring("unable to find .packit in buildpack directory:")))
-					Expect(err).To(MatchError(ContainSubstring("no such file or directory")))
-				})
-			})
-
 			context("when the execution returns an error", func() {
 				it.Before(func() {
 					executable.ExecuteCall.Returns.Error = errors.New("some error")


### PR DESCRIPTION
In https://github.com/paketo-buildpacks/github-config/pull/278, we have removed the requirement for a `.packit` file in the repo to use `jam` as the tooling for building a `packit`-based buildpack. At this point, it probably makes sense to `freezer` to just assume that if it is being used, then it is a `packit`-based buildpack. This removes the check for the `.packit` file as these will be removed from the buildpacks soon.