### PR TITLE
add WithPackager setter for remote and local fetchers

### DIFF
--- a/local_fetcher.go
+++ b/local_fetcher.go
@@ -25,6 +25,11 @@ func NewLocalFetcher(buildpackCache BuildpackCache, packager Packager, namer Nam
 	}
 }
 
+func (l LocalFetcher) WithPackager(packager Packager) LocalFetcher {
+	l.packager = packager
+	return l
+}
+
 func (l LocalFetcher) Get(buildpack LocalBuildpack) (string, error) {
 	buildpackCacheDir := filepath.Join(l.buildpackCache.Dir(), buildpack.Name)
 	if buildpack.Offline {

--- a/remote_fetcher.go
+++ b/remote_fetcher.go
@@ -45,6 +45,11 @@ func NewRemoteFetcher(buildpackCache BuildpackCache, gitReleaseFetcher GitReleas
 	}
 }
 
+func (r RemoteFetcher) WithPackager(packager Packager) RemoteFetcher {
+	r.packager = packager
+	return r
+}
+
 func (r RemoteFetcher) Get(buildpack RemoteBuildpack) (string, error) {
 	release, err := r.gitReleaseFetcher.Get(buildpack.Org, buildpack.Repo)
 	if err != nil {


### PR DESCRIPTION
Enables users to define their own buildpack-packaging logic when fetching buildpacks from local or remote source code. Makes freezer more flexible in that it can still work with non-packit buildpacks that can't be packaged with the default packager.