### PR TITLE
uniform versioning with/without release assets

### DIFF
--- a/remote_fetcher.go
+++ b/remote_fetcher.go
@@ -80,7 +80,7 @@ func (r RemoteFetcher) Get(buildpack RemoteBuildpack) (string, error) {
 	}
 
 	path := cachedEntry.URI
-	tagName := strings.TrimLeft(release.TagName, "v")
+	tagName := strings.TrimPrefix(release.TagName, "v")
 
 	if tagName != cachedEntry.Version || !exist {
 		missingReleaseArtifacts := !(len(release.Assets) > 0)


### PR DESCRIPTION
A lot of buildpacks that use freezer are versioned X.Y.Z (X,Y,Z being
whole numbers) but their releases are tagged vX.Y.Z

This means that for buildpack releases that have attached assets,
freezer packages them with version X.Y.Z and for those without assets,
it packages them as vX.Y.Z.

This commit trims the v prefix to bring uniformity